### PR TITLE
Update zabbix_alerta.py to include the eventId and triggerId 

### DIFF
--- a/zabbix_alerta.py
+++ b/zabbix_alerta.py
@@ -120,6 +120,8 @@ def cli(sendto, summary, body):
     value={ITEM.VALUE1}
     text={TRIGGER.STATUS}: {TRIGGER.NAME}
     tags={EVENT.TAGS}
+    attributes.eventId={EVENT.ID}
+    attributes.triggerId={TRIGGER.ID}
     attributes.ip={HOST.IP1}
     attributes.thresholdInfo={TRIGGER.TEMPLATE.NAME}: {TRIGGER.EXPRESSION}
     attributes.moreInfo=<a href="http://x.x.x.x/tr_events.php?triggerid={TRIGGER.ID}&eventid={EVENT.ID}">Zabbix console</a>


### PR DESCRIPTION
Seems these 2 attributes need to be set for the alerta_zabbix.py plugin on the Alerta end of this to be able to Ack properly.   This was missing from the examples here and in the documentation.

Otherwise the alerta plugin will return when it is not set as per this code from the alerta_zabbix plugin. 
        event_id = alert.attributes.get('eventId', None)
        trigger_id = alert.attributes.get('triggerId', None)
        more_info = alert.attributes.get('moreInfo',None)

        if not event_id:
            return