### PR TITLE
Add timeout gix

### DIFF
--- a/zabbix_alerta.py
+++ b/zabbix_alerta.py
@@ -53,6 +53,8 @@ def parse_zabbix(subject, message):
                 value = value.replace('!!', '')
             else:
                 value = ZBX_SEVERITY_MAP.get(value, 'indeterminate')
+        elif macro == 'timeout':
+            value = int(value)
         elif macro == 'tags':
             value = value.split(',')
         elif macro.startswith('attributes.'):


### PR DESCRIPTION
If timeout is included in the macro make it an int so that it will not throw an error. 